### PR TITLE
Discord Webhook bug fix and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 1. Fork this repository to your own account.  
    ![](https://imgur.com/VUH3ZwB.png)
 2. Go to the Daily Check-In event website https://webstatic-sea.mihoyo.com/ys/event/signin-sea/index.html?act_id=e202102251931481&lang=en-us
-3. Log in with your MiHoYo/Genshin Impact account.
+3. Log in with your MiHoYo/Genshin Impact account.  
+   *If you have never checked in before, manually check in once to ensure that your cookies are set properly.*
 4. Open the developer tools on your web browser (F12 on firefox/chrome)
 5. Click on the "Console" tab
 6. Type in `document.cookie` in the console
@@ -55,4 +56,25 @@
 22. You should see a yellow circle next to the job. Wait for it to become a green check mark.  
     ![](https://imgur.com/NZnhTlc.png)
 
-If you see the green check mark, congratulations, your auto check-in has been successfully set up.
+If you see the green check mark, congratulations, your auto check-in has been successfully set up.  
+Your script will now automatically run every day at your scheduled time, without you needing to have your browser open.
+
+**If you no longer want to check in automatically, you must manually disable your workflow or delete your Github repository.**
+![](https://i.imgur.com/uw8qwTF.png)
+
+## Discord Webhooks
+This is an **OPTIONAL** step to let the script send you a notification on Discord whenever it runs a check-in.
+
+Instructions provided by https://github.com/am-steph/genshin-impact-helper
+1. Edit channel settings. (Create your own discord server or private channel for this)
+   ![](https://i.imgur.com/Q0KFNzv.png)
+2. Go into Integrations and view webhooks.
+   ![](https://i.imgur.com/Z4pfACE.png)
+3. Create a new webhook and copy the URL.
+   ![](https://i.imgur.com/b3ZL3m3.png)
+4. Go back to the "Secrets" tab on the repository and add a new secret called DISCORD_WEBHOOK.
+   ![](https://i.imgur.com/YusKz6V.png)
+5. Run the github action again and check for message in the channel you set the webhook in
+   ![](https://i.imgur.com/0FMvJHW.png)
+   
+To stop receiving Discord notifications, delete your DISCORD_WEBHOOK secret.

--- a/notify.py
+++ b/notify.py
@@ -26,7 +26,7 @@ class Notify(object):
                 与set_data_sub_title互斥,两者都填则本项不生效.
 
     :param DISCORD_WEBHOOK:
-        ## the original repo contained no documentation about how to use this, good luck i guess
+        ## https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
     """
     # Github Actions -> Settings -> Secrets
     # Ensure that the Name exactly matches the parameter names required here

--- a/notify.py
+++ b/notify.py
@@ -32,10 +32,15 @@ class Notify(object):
     # Ensure that the Name exactly matches the parameter names required here
     # And the Value contains the data to be used
 
-    # Custom Push Config
-    PUSH_CONFIG = ''
-    # Discord Webhook
-    DISCORD_WEBHOOK = ''
+    def __init__(self):
+        # Custom Push Config
+        self.PUSH_CONFIG = ''
+        if 'PUSH_CONFIG' in os.environ:
+            self.PUSH_CONFIG = os.environ['PUSH_CONFIG']
+        # Discord Webhook
+        self.DISCORD_WEBHOOK = ''
+        if 'DISCORD_WEBHOOK' in os.environ:
+            self.DISCORD_WEBHOOK = os.environ['DISCORD_WEBHOOK']
 
     def pushTemplate(self, method, url, params=None, data=None, json=None, headers=None, **kwargs):
         name = kwargs.get('name')
@@ -61,8 +66,6 @@ class Notify(object):
 
     def custPush(self, text, status, desp):
         PUSH_CONFIG = self.PUSH_CONFIG
-        if 'PUSH_CONFIG' in os.environ:
-            PUSH_CONFIG = os.environ['PUSH_CONFIG']
 
         if not PUSH_CONFIG:
             log.info(f'Custom Notifications SKIPPED')
@@ -92,8 +95,6 @@ class Notify(object):
 
     def discordWebhook(self, text, status, desp):
         DISCORD_WEBHOOK = self.DISCORD_WEBHOOK
-        if 'DISCORD_WEBHOOK' in os.environ:
-            DISCORD_WEBHOOK = os.environ['DISCORD_WEBHOOK']
 
         if not DISCORD_WEBHOOK:
             log.info(f'Discord SKIPPED')


### PR DESCRIPTION
- Fixed a bug inherited from the original author where class variables in Notify are never initialized
- Consequently, my `if` statement meant to run Notify only when DISCORD_WEBHOOK or PUSH_CONFIG are set in repository secrets now works as intended
- Added documentation into the readme for discord notifications
- Added some troubleshooting info into the readme (e.g. how to stop a workflow)